### PR TITLE
Add basic frontend and deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-rock paper scissors
+# Rock Paper Scissors
+
+This repo contains a simple Rock Paper Scissors smart contract with a minimal front-end.
+
+## Requirements
+
+- Node.js
+- Hardhat
+
+## Running locally
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start a local Hardhat node in one terminal:
+
+```bash
+npm run node
+```
+
+3. In another terminal deploy the contract to the local node:
+
+```bash
+npm run deploy
+```
+
+The deployment script writes the contract address to `frontend/deployed.json`.
+
+4. Serve the front-end:
+
+```bash
+npm start
+```
+
+Open your browser at `http://localhost:8080` and connect with a wallet (e.g. Coinbase Wallet extension) that is configured to use the local Hardhat network (http://127.0.0.1:8545).
+
+## Front-end
+
+The front-end is located in the `frontend/` folder and uses plain HTML, CSS and JavaScript with `ethers.js`.

--- a/frontend/RockPaperScissors.json
+++ b/frontend/RockPaperScissors.json
@@ -1,0 +1,293 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "cancelledBy",
+          "type": "address"
+        }
+      ],
+      "name": "GameCancelled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "creator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "wager",
+          "type": "uint256"
+        }
+      ],
+      "name": "GameCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "joiner",
+          "type": "address"
+        }
+      ],
+      "name": "GameJoined",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "winner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "GameSettled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "player",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "enum RockPaperScissors.Move",
+          "name": "move",
+          "type": "uint8"
+        }
+      ],
+      "name": "MoveRevealed",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "JOIN_TIMEOUT",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "REVEAL_TIMEOUT",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        }
+      ],
+      "name": "cancelGame",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_commit",
+          "type": "bytes32"
+        }
+      ],
+      "name": "createGame",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "gameCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "games",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "player1",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "player2",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "wager",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "commit1",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "commit2",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "enum RockPaperScissors.Move",
+          "name": "reveal1",
+          "type": "uint8"
+        },
+        {
+          "internalType": "enum RockPaperScissors.Move",
+          "name": "reveal2",
+          "type": "uint8"
+        },
+        {
+          "internalType": "enum RockPaperScissors.GameState",
+          "name": "state",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "createdAt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "joinedAt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_commit",
+          "type": "bytes32"
+        }
+      ],
+      "name": "joinGame",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "gameId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "enum RockPaperScissors.Move",
+          "name": "_move",
+          "type": "uint8"
+        },
+        {
+          "internalType": "string",
+          "name": "_salt",
+          "type": "string"
+        }
+      ],
+      "name": "reveal",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,103 @@
+let provider;
+let signer;
+let contract;
+let abi;
+let contractAddress;
+
+async function init() {
+  const res = await fetch('RockPaperScissors.json');
+  const json = await res.json();
+  abi = json.abi;
+  // contractAddress will be filled after deployment script writes to deployed.json
+  try {
+    const addr = await (await fetch('deployed.json')).json();
+    contractAddress = addr.address;
+  } catch (err) {
+    console.warn('Could not load deployed address.');
+  }
+}
+
+async function connect() {
+  if (!window.ethereum) {
+    alert('No wallet found');
+    return;
+  }
+  provider = new ethers.BrowserProvider(window.ethereum);
+  await provider.send('eth_requestAccounts', []);
+  signer = await provider.getSigner();
+  document.getElementById('account').textContent = 'Account: ' + signer.address;
+  if (contractAddress) {
+    contract = new ethers.Contract(contractAddress, abi, signer);
+  }
+}
+
+function randomSalt() {
+  return ethers.hexlify(ethers.randomBytes(32));
+}
+
+async function createGame() {
+  if (!contract) return alert('Contract not connected');
+  const move = Number(document.getElementById('create-move').value);
+  const wager = document.getElementById('create-wager').value;
+  const salt = randomSalt();
+  const commit = ethers.keccak256(ethers.solidityPacked(['uint8','string'], [move, salt]));
+  try {
+    const tx = await contract.createGame(commit, { value: ethers.parseEther(wager) });
+    const receipt = await tx.wait();
+    const gameId = receipt.logs[0].args.gameId;
+    document.getElementById('create-result').textContent = `Game ${gameId} created. Save this salt for reveal: ${salt}`;
+  } catch (err) {
+    document.getElementById('create-result').textContent = err.message;
+  }
+}
+
+async function joinGame() {
+  if (!contract) return alert('Contract not connected');
+  const id = Number(document.getElementById('join-id').value);
+  const move = Number(document.getElementById('join-move').value);
+  const salt = randomSalt();
+  const commit = ethers.keccak256(ethers.solidityPacked(['uint8','string'], [move, salt]));
+  try {
+    const wager = await contract.games(id).then(g => g.wager);
+    const tx = await contract.joinGame(id, commit, { value: wager });
+    await tx.wait();
+    document.getElementById('join-result').textContent = `Joined game with salt: ${salt}`;
+  } catch (err) {
+    document.getElementById('join-result').textContent = err.message;
+  }
+}
+
+async function reveal() {
+  if (!contract) return alert('Contract not connected');
+  const id = Number(document.getElementById('reveal-id').value);
+  const move = Number(document.getElementById('reveal-move').value);
+  const salt = document.getElementById('reveal-salt').value;
+  try {
+    const tx = await contract.reveal(id, move, salt);
+    await tx.wait();
+    document.getElementById('reveal-result').textContent = 'Revealed!';
+  } catch (err) {
+    document.getElementById('reveal-result').textContent = err.message;
+  }
+}
+
+async function cancel() {
+  if (!contract) return alert('Contract not connected');
+  const id = Number(document.getElementById('cancel-id').value);
+  try {
+    const tx = await contract.cancelGame(id);
+    await tx.wait();
+    document.getElementById('cancel-result').textContent = 'Cancelled';
+  } catch (err) {
+    document.getElementById('cancel-result').textContent = err.message;
+  }
+}
+
+window.addEventListener('load', async () => {
+  await init();
+  document.getElementById('connect').onclick = connect;
+  document.getElementById('create').onclick = createGame;
+  document.getElementById('join').onclick = joinGame;
+  document.getElementById('reveal').onclick = reveal;
+  document.getElementById('cancel').onclick = cancel;
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Rock Paper Scissors</title>
+<link rel="stylesheet" href="style.css">
+<script src="https://cdn.jsdelivr.net/npm/ethers@6.8.1/dist/ethers.min.js"></script>
+</head>
+<body>
+<h1>Rock Paper Scissors</h1>
+<button id="connect">Connect Wallet</button>
+<div id="account"></div>
+
+<h2>Create Game</h2>
+<label>Move:
+<select id="create-move">
+<option value="1">Rock</option>
+<option value="2">Paper</option>
+<option value="3">Scissors</option>
+</select>
+</label>
+<label>Wager (ETH): <input id="create-wager" type="number" min="0" step="0.01"></label>
+<button id="create">Create</button>
+<div id="create-result"></div>
+
+<h2>Join Game</h2>
+<label>Game ID: <input id="join-id" type="number" min="0"></label>
+<label>Move:
+<select id="join-move">
+<option value="1">Rock</option>
+<option value="2">Paper</option>
+<option value="3">Scissors</option>
+</select>
+</label>
+<button id="join">Join</button>
+<div id="join-result"></div>
+
+<h2>Reveal Move</h2>
+<label>Game ID: <input id="reveal-id" type="number" min="0"></label>
+<label>Move:
+<select id="reveal-move">
+<option value="1">Rock</option>
+<option value="2">Paper</option>
+<option value="3">Scissors</option>
+</select>
+</label>
+<label>Salt: <input id="reveal-salt" type="text"></label>
+<button id="reveal">Reveal</button>
+<div id="reveal-result"></div>
+
+<h2>Cancel Game</h2>
+<label>Game ID: <input id="cancel-id" type="number" min="0"></label>
+<button id="cancel">Cancel</button>
+<div id="cancel-result"></div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,23 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+label {
+    display: block;
+    margin-top: 10px;
+}
+button {
+    margin-top: 10px;
+}
+#account {
+    margin-bottom: 20px;
+    font-weight: bold;
+}
+
+.result {
+    margin-top: 5px;
+    color: green;
+}
+.error {
+    color: red;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "node": "hardhat node",
+    "deploy": "hardhat run scripts/deploy.js --network localhost",
+    "start": "npx http-server frontend -c-1"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+async function main() {
+  const RPS = await ethers.getContractFactory('RockPaperScissors');
+  const rps = await RPS.deploy();
+  await rps.waitForDeployment();
+  const address = await rps.getAddress();
+  console.log('RockPaperScissors deployed to:', address);
+  fs.writeFileSync('frontend/deployed.json', JSON.stringify({ address }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add simple HTML/CSS/JS frontend using ethers.js
- expose ABI for contract
- add deployment helper script
- provide npm scripts for running local node, deploy and serve
- update README with instructions

## Testing
- `npm test` *(fails: no tests)*
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68705076e4b483288749aff72eac8b4b