### PR TITLE
Add game list UI with timers

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,14 @@ let contract;
 let abi;
 let contractAddress;
 
+function formatTimeLeft(seconds) {
+  if (seconds <= 0) return 'Expired';
+  const h = Math.floor(seconds / 3600).toString().padStart(2, '0');
+  const m = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
+  const s = Math.floor(seconds % 60).toString().padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
 async function init() {
   const res = await fetch('RockPaperScissors.json');
   const json = await res.json();
@@ -26,13 +34,46 @@ async function connect() {
   await provider.send('eth_requestAccounts', []);
   signer = await provider.getSigner();
   document.getElementById('account').textContent = 'Account: ' + signer.address;
-  if (contractAddress) {
-    contract = new ethers.Contract(contractAddress, abi, signer);
-  }
+    if (contractAddress) {
+      contract = new ethers.Contract(contractAddress, abi, signer);
+      await loadGames();
+    }
 }
 
 function randomSalt() {
   return ethers.hexlify(ethers.randomBytes(32));
+}
+
+async function loadGames() {
+  if (!contract) return;
+  const count = Number(await contract.gameCount());
+  const joinTimeout = Number(await contract.JOIN_TIMEOUT());
+  const revealTimeout = Number(await contract.REVEAL_TIMEOUT());
+  const now = Math.floor(Date.now() / 1000);
+  let active = '<table><tr><th>ID</th><th>Wager (ETH)</th><th>Time Left</th></tr>';
+  let completed = '<table><tr><th>ID</th><th>Wager (ETH)</th></tr>';
+  for (let i = 0; i < count; i++) {
+    const g = await contract.games(i);
+    const wager = ethers.formatEther(g.wager);
+    const state = Number(g.state);
+    if (state === 3) {
+      completed += `<tr><td>${i}</td><td>${wager}</td></tr>`;
+    } else {
+      let timeLeft = '';
+      if (state === 0) {
+        const left = Number(g.createdAt) + joinTimeout - now;
+        timeLeft = formatTimeLeft(left);
+      } else if (state === 1) {
+        const left = Number(g.joinedAt) + revealTimeout - now;
+        timeLeft = formatTimeLeft(left);
+      }
+      active += `<tr><td>${i}</td><td>${wager}</td><td>${timeLeft}</td></tr>`;
+    }
+  }
+  active += '</table>';
+  completed += '</table>';
+  document.getElementById('active-games').innerHTML = active;
+  document.getElementById('completed-games').innerHTML = completed;
 }
 
 async function createGame() {
@@ -46,6 +87,7 @@ async function createGame() {
     const receipt = await tx.wait();
     const gameId = receipt.logs[0].args.gameId;
     document.getElementById('create-result').textContent = `Game ${gameId} created. Save this salt for reveal: ${salt}`;
+    await loadGames();
   } catch (err) {
     document.getElementById('create-result').textContent = err.message;
   }
@@ -62,6 +104,7 @@ async function joinGame() {
     const tx = await contract.joinGame(id, commit, { value: wager });
     await tx.wait();
     document.getElementById('join-result').textContent = `Joined game with salt: ${salt}`;
+    await loadGames();
   } catch (err) {
     document.getElementById('join-result').textContent = err.message;
   }
@@ -76,6 +119,7 @@ async function reveal() {
     const tx = await contract.reveal(id, move, salt);
     await tx.wait();
     document.getElementById('reveal-result').textContent = 'Revealed!';
+    await loadGames();
   } catch (err) {
     document.getElementById('reveal-result').textContent = err.message;
   }
@@ -88,6 +132,7 @@ async function cancel() {
     const tx = await contract.cancelGame(id);
     await tx.wait();
     document.getElementById('cancel-result').textContent = 'Cancelled';
+    await loadGames();
   } catch (err) {
     document.getElementById('cancel-result').textContent = err.message;
   }
@@ -100,4 +145,16 @@ window.addEventListener('load', async () => {
   document.getElementById('join').onclick = joinGame;
   document.getElementById('reveal').onclick = reveal;
   document.getElementById('cancel').onclick = cancel;
+  document.getElementById('tab-active').onclick = () => {
+    document.getElementById('tab-active').classList.add('active');
+    document.getElementById('tab-completed').classList.remove('active');
+    document.getElementById('active-games').style.display = '';
+    document.getElementById('completed-games').style.display = 'none';
+  };
+  document.getElementById('tab-completed').onclick = () => {
+    document.getElementById('tab-completed').classList.add('active');
+    document.getElementById('tab-active').classList.remove('active');
+    document.getElementById('active-games').style.display = 'none';
+    document.getElementById('completed-games').style.display = '';
+  };
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,6 +56,14 @@
     <button id="cancel">Cancel</button>
     <div id="cancel-result"></div>
 
+    <h2>Games</h2>
+    <div class="tabs">
+        <button id="tab-active" class="tab active">Active Games</button>
+        <button id="tab-completed" class="tab">Completed Games</button>
+    </div>
+    <div id="active-games" class="games-list"></div>
+    <div id="completed-games" class="games-list" style="display:none"></div>
+
     <script src="app.js"></script>
 </body>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -21,3 +21,23 @@ button {
 .error {
     color: red;
 }
+
+.tabs {
+    margin-top: 20px;
+}
+.tab {
+    margin-right: 10px;
+    padding: 5px 10px;
+    cursor: pointer;
+}
+.tab.active {
+    font-weight: bold;
+}
+.games-list table {
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+.games-list th, .games-list td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+}


### PR DESCRIPTION
## Summary
- list active and completed games
- show timers for join/reveal deadline
- add tabbed UI for viewing games

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68710d86e6a883288b8e46af82841013