### PR TITLE
Improve frontend UI with lobby and game room

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,22 +1,24 @@
-let provider;
-let signer;
-let contract;
-let abi;
-let contractAddress;
+let provider, signer, contract, abi, contractAddress;
+let currentGameId;
 
-function formatTimeLeft(seconds) {
-  if (seconds <= 0) return 'Expired';
-  const h = Math.floor(seconds / 3600).toString().padStart(2, '0');
-  const m = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
-  const s = Math.floor(seconds % 60).toString().padStart(2, '0');
-  return `${h}:${m}:${s}`;
+function moveName(m) {
+  return ['None', 'Rock', 'Paper', 'Scissors'][m] || 'Unknown';
+}
+
+function statusName(s) {
+  return ['Open', 'Committed', 'Revealed', 'Finished'][s] || 'Unknown';
+}
+
+function showSection(id) {
+  document.querySelectorAll('.section').forEach(el => el.style.display = 'none');
+  const el = document.getElementById(id);
+  if (el) el.style.display = '';
 }
 
 async function init() {
   const res = await fetch('RockPaperScissors.json');
   const json = await res.json();
   abi = json.abi;
-  // contractAddress will be filled after deployment script writes to deployed.json
   try {
     const addr = await (await fetch('deployed.json')).json();
     contractAddress = addr.address;
@@ -34,46 +36,14 @@ async function connect() {
   await provider.send('eth_requestAccounts', []);
   signer = await provider.getSigner();
   document.getElementById('account').textContent = 'Account: ' + signer.address;
-    if (contractAddress) {
-      contract = new ethers.Contract(contractAddress, abi, signer);
-      await loadGames();
-    }
+  if (contractAddress) {
+    contract = new ethers.Contract(contractAddress, abi, signer);
+    showSection('menu');
+  }
 }
 
 function randomSalt() {
   return ethers.hexlify(ethers.randomBytes(32));
-}
-
-async function loadGames() {
-  if (!contract) return;
-  const count = Number(await contract.gameCount());
-  const joinTimeout = Number(await contract.JOIN_TIMEOUT());
-  const revealTimeout = Number(await contract.REVEAL_TIMEOUT());
-  const now = Math.floor(Date.now() / 1000);
-  let active = '<table><tr><th>ID</th><th>Wager (ETH)</th><th>Time Left</th></tr>';
-  let completed = '<table><tr><th>ID</th><th>Wager (ETH)</th></tr>';
-  for (let i = 0; i < count; i++) {
-    const g = await contract.games(i);
-    const wager = ethers.formatEther(g.wager);
-    const state = Number(g.state);
-    if (state === 3) {
-      completed += `<tr><td>${i}</td><td>${wager}</td></tr>`;
-    } else {
-      let timeLeft = '';
-      if (state === 0) {
-        const left = Number(g.createdAt) + joinTimeout - now;
-        timeLeft = formatTimeLeft(left);
-      } else if (state === 1) {
-        const left = Number(g.joinedAt) + revealTimeout - now;
-        timeLeft = formatTimeLeft(left);
-      }
-      active += `<tr><td>${i}</td><td>${wager}</td><td>${timeLeft}</td></tr>`;
-    }
-  }
-  active += '</table>';
-  completed += '</table>';
-  document.getElementById('active-games').innerHTML = active;
-  document.getElementById('completed-games').innerHTML = completed;
 }
 
 async function createGame() {
@@ -81,80 +51,132 @@ async function createGame() {
   const move = Number(document.getElementById('create-move').value);
   const wager = document.getElementById('create-wager').value;
   const salt = randomSalt();
-  const commit = ethers.keccak256(ethers.solidityPacked(['uint8','string'], [move, salt]));
+  const commit = ethers.keccak256(ethers.solidityPacked(['uint8', 'string'], [move, salt]));
   try {
     const tx = await contract.createGame(commit, { value: ethers.parseEther(wager) });
     const receipt = await tx.wait();
     const gameId = receipt.logs[0].args.gameId;
     document.getElementById('create-result').textContent = `Game ${gameId} created. Save this salt for reveal: ${salt}`;
-    await loadGames();
+    await showGame(gameId);
   } catch (err) {
     document.getElementById('create-result').textContent = err.message;
   }
 }
 
-async function joinGame() {
-  if (!contract) return alert('Contract not connected');
-  const id = Number(document.getElementById('join-id').value);
-  const move = Number(document.getElementById('join-move').value);
+async function loadGames(filter = 'all') {
+  if (!contract) return;
+  const count = Number(await contract.gameCount());
+  const list = [];
+  for (let i = 0; i < count; i++) {
+    const g = await contract.games(i);
+    if (Number(g.state) === 3) continue;
+    const mine = signer && (signer.address === g.player1 || signer.address === g.player2);
+    if (filter === 'open' && Number(g.state) !== 0) continue;
+    if (filter === 'mine' && !mine) continue;
+    list.push({ id: i, wager: ethers.formatEther(g.wager), state: Number(g.state) });
+  }
+  let html = '<table><tr><th>ID</th><th>Wager (ETH)</th><th>Status</th></tr>';
+  list.forEach(g => {
+    html += `<tr class="game-row" data-id="${g.id}"><td>${g.id}</td><td>${g.wager}</td><td>${statusName(g.state)}</td></tr>`;
+  });
+  html += '</table>';
+  const container = document.getElementById('games-list');
+  container.innerHTML = html;
+  container.querySelectorAll('.game-row').forEach(row => {
+    row.onclick = () => showGame(row.dataset.id);
+  });
+}
+
+async function joinGame(id, move) {
   const salt = randomSalt();
-  const commit = ethers.keccak256(ethers.solidityPacked(['uint8','string'], [move, salt]));
+  const commit = ethers.keccak256(ethers.solidityPacked(['uint8', 'string'], [move, salt]));
   try {
     const wager = await contract.games(id).then(g => g.wager);
     const tx = await contract.joinGame(id, commit, { value: wager });
     await tx.wait();
-    document.getElementById('join-result').textContent = `Joined game with salt: ${salt}`;
-    await loadGames();
+    document.getElementById('room-status').textContent = `Joined! Save salt: ${salt}`;
+    await showGame(id);
   } catch (err) {
-    document.getElementById('join-result').textContent = err.message;
+    document.getElementById('room-status').textContent = err.message;
   }
 }
 
-async function reveal() {
-  if (!contract) return alert('Contract not connected');
-  const id = Number(document.getElementById('reveal-id').value);
-  const move = Number(document.getElementById('reveal-move').value);
-  const salt = document.getElementById('reveal-salt').value;
+async function revealMove(id, move, salt) {
   try {
     const tx = await contract.reveal(id, move, salt);
     await tx.wait();
-    document.getElementById('reveal-result').textContent = 'Revealed!';
-    await loadGames();
+    document.getElementById('room-status').textContent = 'Revealed!';
+    await showGame(id);
   } catch (err) {
-    document.getElementById('reveal-result').textContent = err.message;
+    document.getElementById('room-status').textContent = err.message;
   }
 }
 
-async function cancel() {
-  if (!contract) return alert('Contract not connected');
-  const id = Number(document.getElementById('cancel-id').value);
-  try {
-    const tx = await contract.cancelGame(id);
-    await tx.wait();
-    document.getElementById('cancel-result').textContent = 'Cancelled';
-    await loadGames();
-  } catch (err) {
-    document.getElementById('cancel-result').textContent = err.message;
+function revealForm(num) {
+  return `<label>Move:
+    <select id="rev-move${num}">
+      <option value="1">Rock</option>
+      <option value="2">Paper</option>
+      <option value="3">Scissors</option>
+    </select>
+  </label>
+  <label>Salt: <input id="rev-salt${num}" type="text"></label>
+  <button id="reveal-btn${num}">Reveal</button>`;
+}
+
+async function showGame(id) {
+  if (!contract) return;
+  currentGameId = Number(id);
+  const g = await contract.games(id);
+
+  document.getElementById('room-id').textContent = id;
+  document.getElementById('room-status').textContent = statusName(Number(g.state));
+  document.getElementById('player1-info').textContent = g.player1 + (Number(g.reveal1) ? ' - ' + moveName(Number(g.reveal1)) : '');
+  document.getElementById('player2-info').textContent = (g.player2 === ethers.ZeroAddress ? 'Waiting for player 2' : g.player2) + (Number(g.reveal2) ? ' - ' + moveName(Number(g.reveal2)) : '');
+
+  document.getElementById('player1-action').innerHTML = '';
+  document.getElementById('player2-action').innerHTML = '';
+
+  if (Number(g.state) === 0 && signer.address !== g.player1 && g.player2 === ethers.ZeroAddress) {
+    document.getElementById('player2-action').innerHTML = `<label>Move:
+      <select id="join-move">
+        <option value="1">Rock</option>
+        <option value="2">Paper</option>
+        <option value="3">Scissors</option>
+      </select>
+    </label>
+    <button id="join-btn">Join</button>`;
+    document.getElementById('join-btn').onclick = () => joinGame(id, Number(document.getElementById('join-move').value));
+  } else if (Number(g.state) === 1) {
+    if (signer.address === g.player1 && Number(g.reveal1) === 0) {
+      document.getElementById('player1-action').innerHTML = revealForm('1');
+      document.getElementById('reveal-btn1').onclick = () => revealMove(id, Number(document.getElementById('rev-move1').value), document.getElementById('rev-salt1').value);
+    }
+    if (signer.address === g.player2 && Number(g.reveal2) === 0) {
+      document.getElementById('player2-action').innerHTML = revealForm('2');
+      document.getElementById('reveal-btn2').onclick = () => revealMove(id, Number(document.getElementById('rev-move2').value), document.getElementById('rev-salt2').value);
+    }
   }
+
+  showSection('game-room');
+}
+
+function setFilter(btnId, filter) {
+  document.querySelectorAll('.tab').forEach(b => b.classList.remove('active'));
+  document.getElementById(btnId).classList.add('active');
+  loadGames(filter);
 }
 
 window.addEventListener('load', async () => {
   await init();
   document.getElementById('connect').onclick = connect;
+  document.getElementById('btn-new-game').onclick = () => showSection('create-section');
+  document.getElementById('btn-view-games').onclick = () => { showSection('games-page'); loadGames(); };
+  document.getElementById('create-back').onclick = () => showSection('menu');
+  document.getElementById('games-back').onclick = () => showSection('menu');
+  document.getElementById('room-back').onclick = () => { showSection('games-page'); loadGames(); };
   document.getElementById('create').onclick = createGame;
-  document.getElementById('join').onclick = joinGame;
-  document.getElementById('reveal').onclick = reveal;
-  document.getElementById('cancel').onclick = cancel;
-  document.getElementById('tab-active').onclick = () => {
-    document.getElementById('tab-active').classList.add('active');
-    document.getElementById('tab-completed').classList.remove('active');
-    document.getElementById('active-games').style.display = '';
-    document.getElementById('completed-games').style.display = 'none';
-  };
-  document.getElementById('tab-completed').onclick = () => {
-    document.getElementById('tab-completed').classList.add('active');
-    document.getElementById('tab-active').classList.remove('active');
-    document.getElementById('active-games').style.display = 'none';
-    document.getElementById('completed-games').style.display = '';
-  };
+  document.getElementById('filter-all').onclick = () => setFilter('filter-all', 'all');
+  document.getElementById('filter-open').onclick = () => setFilter('filter-open', 'open');
+  document.getElementById('filter-mine').onclick = () => setFilter('filter-mine', 'mine');
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -50,7 +50,8 @@ async function createGame() {
   if (!contract) return alert('Contract not connected');
   const move = Number(document.getElementById('create-move').value);
   const wager = document.getElementById('create-wager').value;
-  const salt = randomSalt();
+  const customSalt = document.getElementById('create-salt').value.trim();
+  const salt = customSalt || randomSalt();
   const commit = ethers.keccak256(ethers.solidityPacked(['uint8', 'string'], [move, salt]));
   try {
     const tx = await contract.createGame(commit, { value: ethers.parseEther(wager) });
@@ -87,8 +88,8 @@ async function loadGames(filter = 'all') {
   });
 }
 
-async function joinGame(id, move) {
-  const salt = randomSalt();
+async function joinGame(id, move, customSalt) {
+  const salt = customSalt && customSalt.trim() ? customSalt.trim() : randomSalt();
   const commit = ethers.keccak256(ethers.solidityPacked(['uint8', 'string'], [move, salt]));
   try {
     const wager = await contract.games(id).then(g => g.wager);
@@ -145,8 +146,13 @@ async function showGame(id) {
         <option value="3">Scissors</option>
       </select>
     </label>
+    <label>Salt: <input id="join-salt" type="text" placeholder="leave blank for random"></label>
     <button id="join-btn">Join</button>`;
-    document.getElementById('join-btn').onclick = () => joinGame(id, Number(document.getElementById('join-move').value));
+    document.getElementById('join-btn').onclick = () => joinGame(
+      id,
+      Number(document.getElementById('join-move').value),
+      document.getElementById('join-salt').value
+    );
   } else if (Number(g.state) === 1) {
     if (signer.address === g.player1 && Number(g.reveal1) === 0) {
       document.getElementById('player1-action').innerHTML = revealForm('1');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,6 +29,7 @@
             </select>
         </label>
         <label>Wager (ETH): <input id="create-wager" type="number" min="0" step="0.01"></label>
+        <label>Salt (optional): <input id="create-salt" type="text" placeholder="leave blank for random"></label>
         <button id="create">Create</button>
         <div id="create-result" class="result"></div>
         <button id="create-back" class="back">Back</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,11 +52,13 @@
             <div class="player-col">
                 <h3>Player 1</h3>
                 <div id="player1-info"></div>
+                <div id="player1-salt" class="salt"></div>
                 <div id="player1-action"></div>
             </div>
             <div class="player-col">
                 <h3>Player 2</h3>
                 <div id="player2-info"></div>
+                <div id="player2-salt" class="salt"></div>
                 <div id="player2-action"></div>
             </div>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,55 +14,54 @@
     <button id="connect">Connect Wallet</button>
     <div id="account"></div>
 
-    <h2>Create Game</h2>
-    <label>Move:
-        <select id="create-move">
-            <option value="1">Rock</option>
-            <option value="2">Paper</option>
-            <option value="3">Scissors</option>
-        </select>
-    </label>
-    <label>Wager (ETH): <input id="create-wager" type="number" min="0" step="0.01"></label>
-    <button id="create">Create</button>
-    <div id="create-result"></div>
-
-    <h2>Join Game</h2>
-    <label>Game ID: <input id="join-id" type="number" min="0"></label>
-    <label>Move:
-        <select id="join-move">
-            <option value="1">Rock</option>
-            <option value="2">Paper</option>
-            <option value="3">Scissors</option>
-        </select>
-    </label>
-    <button id="join">Join</button>
-    <div id="join-result"></div>
-
-    <h2>Reveal Move</h2>
-    <label>Game ID: <input id="reveal-id" type="number" min="0"></label>
-    <label>Move:
-        <select id="reveal-move">
-            <option value="1">Rock</option>
-            <option value="2">Paper</option>
-            <option value="3">Scissors</option>
-        </select>
-    </label>
-    <label>Salt: <input id="reveal-salt" type="text"></label>
-    <button id="reveal">Reveal</button>
-    <div id="reveal-result"></div>
-
-    <h2>Cancel Game</h2>
-    <label>Game ID: <input id="cancel-id" type="number" min="0"></label>
-    <button id="cancel">Cancel</button>
-    <div id="cancel-result"></div>
-
-    <h2>Games</h2>
-    <div class="tabs">
-        <button id="tab-active" class="tab active">Active Games</button>
-        <button id="tab-completed" class="tab">Completed Games</button>
+    <div id="menu" class="section" style="display:none">
+        <button id="btn-new-game" class="big-btn">Start New Game</button>
+        <button id="btn-view-games" class="big-btn">View Active Games</button>
     </div>
-    <div id="active-games" class="games-list"></div>
-    <div id="completed-games" class="games-list" style="display:none"></div>
+
+    <div id="create-section" class="section" style="display:none">
+        <h2>Create Game</h2>
+        <label>Move:
+            <select id="create-move">
+                <option value="1">Rock</option>
+                <option value="2">Paper</option>
+                <option value="3">Scissors</option>
+            </select>
+        </label>
+        <label>Wager (ETH): <input id="create-wager" type="number" min="0" step="0.01"></label>
+        <button id="create">Create</button>
+        <div id="create-result" class="result"></div>
+        <button id="create-back" class="back">Back</button>
+    </div>
+
+    <div id="games-page" class="section" style="display:none">
+        <h2>Active Games</h2>
+        <div class="tabs">
+            <button id="filter-all" class="tab active">All</button>
+            <button id="filter-open" class="tab">Waiting</button>
+            <button id="filter-mine" class="tab">My Games</button>
+        </div>
+        <div id="games-list" class="games-list"></div>
+        <button id="games-back" class="back">Back</button>
+    </div>
+
+    <div id="game-room" class="section" style="display:none">
+        <h2>Game <span id="room-id"></span></h2>
+        <div class="room">
+            <div class="player-col">
+                <h3>Player 1</h3>
+                <div id="player1-info"></div>
+                <div id="player1-action"></div>
+            </div>
+            <div class="player-col">
+                <h3>Player 2</h3>
+                <div id="player2-info"></div>
+                <div id="player2-action"></div>
+            </div>
+        </div>
+        <div id="room-status"></div>
+        <button id="room-back" class="back">Back</button>
+    </div>
 
     <script src="app.js"></script>
 </body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -99,3 +99,8 @@ button {
 .error {
     color: red;
 }
+
+.salt {
+    margin-top: 5px;
+    font-style: italic;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,43 +1,101 @@
 body {
     font-family: Arial, sans-serif;
     margin: 20px;
+    background: #f5f5f5;
+    color: #333;
 }
+
+h1 {
+    text-align: center;
+}
+
 label {
     display: block;
     margin-top: 10px;
 }
+
 button {
     margin-top: 10px;
 }
+
 #account {
     margin-bottom: 20px;
     font-weight: bold;
+}
+
+.section {
+    margin-top: 20px;
+}
+
+.big-btn {
+    padding: 15px 25px;
+    font-size: 18px;
+    background: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    margin: 10px;
+    cursor: pointer;
+}
+
+.big-btn:hover {
+    background: #45a049;
+}
+
+.back {
+    margin-top: 20px;
+}
+
+.tabs {
+    margin-top: 20px;
+}
+
+.tab {
+    margin-right: 10px;
+    padding: 5px 10px;
+    cursor: pointer;
+}
+
+.tab.active {
+    font-weight: bold;
+    background: #e0e0e0;
+}
+
+.games-list table {
+    border-collapse: collapse;
+    margin-top: 10px;
+    width: 100%;
+}
+
+.games-list th, .games-list td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+}
+
+.game-row {
+    cursor: pointer;
+}
+
+.room {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    margin-top: 10px;
+}
+
+.player-col {
+    flex: 1;
+    background: #fff;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
 }
 
 .result {
     margin-top: 5px;
     color: green;
 }
+
 .error {
     color: red;
-}
-
-.tabs {
-    margin-top: 20px;
-}
-.tab {
-    margin-right: 10px;
-    padding: 5px 10px;
-    cursor: pointer;
-}
-.tab.active {
-    font-weight: bold;
-}
-.games-list table {
-    border-collapse: collapse;
-    margin-top: 10px;
-}
-.games-list th, .games-list td {
-    border: 1px solid #ccc;
-    padding: 4px 8px;
 }


### PR DESCRIPTION
## Summary
- overhaul frontend layout
- add lobby with options to create or view games
- implement filterable games list
- add game room view with join & reveal actions
- style updates for a more colorful interface

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_687160851f6c83288c277907c6affd8e