### PR TITLE
Store moves in IndexedDB and show them

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,12 +55,14 @@
                 <h3>Player 1</h3>
                 <div id="player1-info"></div>
                 <div id="player1-salt" class="salt"></div>
+                <div id="player1-move" class="move"></div>
                 <div id="player1-action"></div>
             </div>
             <div class="player-col">
                 <h3>Player 2</h3>
                 <div id="player2-info"></div>
                 <div id="player2-salt" class="salt"></div>
+                <div id="player2-move" class="move"></div>
                 <div id="player2-action"></div>
             </div>
         </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -104,3 +104,7 @@ button {
     margin-top: 5px;
     font-style: italic;
 }
+.move {
+    margin-top: 5px;
+    font-style: italic;
+}


### PR DESCRIPTION
## Summary
- migrate local commitment storage to IndexedDB and scope by account
- display saved move and salt when viewing a game
- add move placeholders to HTML and matching styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871961458e083289efa8ba8e1e50915